### PR TITLE
feat: implement Safari iOS UI color sampling fix

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,17 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${inter.className} bg-[#231A19]`}>
+      <body className={`${inter.className}`}>
+        {/* Safari Color Sampling Elements */}
+        <div
+          className="fixed top-0 left-0 w-full h-20 pointer-events-none"
+          style={{ backgroundColor: '#766F61', zIndex: -1 }}
+        />
+        <div
+          className="fixed bottom-0 left-0 w-full h-20 pointer-events-none"
+          style={{ backgroundColor: '#231A19', zIndex: -1 }}
+        />
+
         {/* Fixed Background */}
         <div className="fixed inset-0 w-full h-full">
           <Image


### PR DESCRIPTION
## Summary
• Implements strategic Safari iOS UI color sampling technique
• Adds invisible DOM elements positioned at viewport top/bottom for Safari to sample colors from
• Removes body background color to enable Safari's automatic DOM element sampling
• Attempts to achieve different colors for top Safari UI (#766F61) vs bottom Safari UI (#231A19)

## Technical Approach
- **Color Sampling Elements**: Fixed positioned divs at top and bottom of viewport
- **Top Element**: `#766F61` color to match background image top
- **Bottom Element**: `#231A19` color to match background image bottom  
- **Non-Interactive**: `pointer-events-none` to avoid user interaction interference
- **Layered**: Positioned behind content but above background image

## Why This Approach?
Safari iOS automatically samples colors from visible DOM elements in the viewport to determine UI colors. By strategically placing colored elements where Safari expects to find them, we can influence its color selection for different UI areas.

## Testing
- Currently doesn't work in development mode
- May work correctly in production/deployed environment due to Safari behavior differences
- Worth testing on Vercel deployment to verify production behavior

🤖 Generated with [Claude Code](https://claude.ai/code)