### PR TITLE
fix: Features section background layers for desktop view

### DIFF
--- a/src/components/sections/Features.tsx
+++ b/src/components/sections/Features.tsx
@@ -452,22 +452,22 @@ export default function Features() {
       data-section="features"
       className="relative min-h-screen flex flex-row overflow-hidden"
     >
-      {/* Background layers - moved to section level for mobile */}
+      {/* Background layers - mobile: full width, desktop: right side only */}
       <div
         ref={backgroundLayer1Ref}
-        className="absolute inset-0 bg-gradient-to-br from-black/25 via-black/20 to-transparent md:bg-black/15 backdrop-blur-sm z-10"
+        className="absolute inset-0 md:left-1/2 bg-gradient-to-br from-black/25 via-black/20 to-transparent md:bg-black/15 backdrop-blur-sm z-10"
       />
       <div
         ref={backgroundLayer2Ref}
-        className="absolute inset-0 bg-gradient-to-tr from-black/30 via-black/25 to-black/10 md:bg-black/15 z-20"
+        className="absolute inset-0 md:left-1/2 bg-gradient-to-tr from-black/30 via-black/25 to-black/10 md:bg-black/15 z-20"
       />
       <div
         ref={backgroundLayer3Ref}
-        className="absolute inset-0 bg-gradient-to-bl from-transparent via-black/30 to-black/25 md:bg-black/15 z-30"
+        className="absolute inset-0 md:left-1/2 bg-gradient-to-bl from-transparent via-black/30 to-black/25 md:bg-black/15 z-30"
       />
       <div
         ref={backgroundLayer4Ref}
-        className="absolute inset-0 bg-gradient-to-tl from-black/40 via-black/35 to-black/20 md:bg-black/20 z-35"
+        className="absolute inset-0 md:left-1/2 bg-gradient-to-tl from-black/40 via-black/35 to-black/20 md:bg-black/20 z-35"
       />
 
       <div className="hidden md:flex flex-1 flex-col justify-center items-center p-10 relative z-40">


### PR DESCRIPTION
## Summary
Fixes regression in Features section where background layers were covering the entire section width on desktop instead of only the right side.

## Changes
- Added `md:left-1/2` to all four background layer divs
- Background layers now only cover the right half of the section on desktop (where InfoSections are located)
- Maintains full-width background coverage on mobile as designed
- Left side demo area on desktop now has no background overlay

## Test plan
- [x] Verify desktop view shows background only on right side
- [x] Verify mobile view maintains full-width background coverage
- [x] Verify animations and interactions still work correctly
- [x] Test on different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Features section’s background gradients for responsive behavior: full-bleed on mobile, constrained to the right half on medium and larger screens.
  * Improves visual balance and readability on larger displays while preserving an immersive look on small screens.
  * Reduces background overlap with text on desktops for better content focus.
  * Visual-only refinement; no changes to functionality or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->