### PR TITLE
fix: mobile overview animation looping and container visibility

### DIFF
--- a/src/components/sections/Overview.tsx
+++ b/src/components/sections/Overview.tsx
@@ -189,14 +189,25 @@ export default function Overview() {
       mobileDemoRightRef.current,
     ];
 
-    [...desktopContainers, ...mobileContainers].forEach((container, index) => {
+    // Handle desktop containers - they toggle based on activeSection
+    desktopContainers.forEach((container, index) => {
       if (container) {
-        const isLeftContainer = index % 2 === 0;
+        const isLeftContainer = index === 0;
         const isActive =
           (activeSection === 'left' && isLeftContainer) ||
           (activeSection === 'right' && !isLeftContainer);
         gsap.set(container, {
           opacity: isActive ? 1 : 0,
+          y: 0,
+        });
+      }
+    });
+
+    // Handle mobile containers - both should always be visible
+    mobileContainers.forEach((container) => {
+      if (container) {
+        gsap.set(container, {
+          opacity: 1,
           y: 0,
         });
       }
@@ -439,24 +450,18 @@ export default function Overview() {
           className="md:hidden h-[640px] w-full"
         >
           <ChatDemoFull
+            key={`mobile-left-${currentStayOnTrackScenario}`}
             className="h-full"
             scenarioIndex={currentStayOnTrackScenario}
-            isActive={isMobile ? true : activeSection === 'left'}
+            isActive={true}
             enableWaitlistInteraction={true}
             onInteractionAttempt={waitlistInteraction.handleInteractionAttempt}
             source="overview"
             onComplete={() => {
               // Auto-restart with next scenario after 2 seconds
               setTimeout(() => {
-                if (activeSection === 'left') {
-                  const nextScenario = getNextStayOnTrackScenario();
-                  setCurrentStayOnTrackScenario(nextScenario);
-                  // On mobile, just restart in place. On desktop, toggle sections
-                  if (!isMobile) {
-                    setActiveSection('right');
-                    setTimeout(() => setActiveSection('left'), 100);
-                  }
-                }
+                const nextScenario = getNextStayOnTrackScenario();
+                setCurrentStayOnTrackScenario(nextScenario);
               }, 2000);
             }}
           />
@@ -477,24 +482,18 @@ export default function Overview() {
           className="md:hidden h-[640px] w-full"
         >
           <ChatDemoFull
+            key={`mobile-right-${currentSharedIntelligenceScenario}`}
             className="h-full"
             scenarioIndex={currentSharedIntelligenceScenario}
-            isActive={isMobile ? true : activeSection === 'right'}
+            isActive={true}
             enableWaitlistInteraction={true}
             onInteractionAttempt={waitlistInteraction.handleInteractionAttempt}
             source="overview"
             onComplete={() => {
               // Auto-restart with next scenario after 2 seconds
               setTimeout(() => {
-                if (activeSection === 'right') {
-                  const nextScenario = getNextSharedIntelligenceScenario();
-                  setCurrentSharedIntelligenceScenario(nextScenario);
-                  // On mobile, just restart in place. On desktop, toggle sections
-                  if (!isMobile) {
-                    setActiveSection('left');
-                    setTimeout(() => setActiveSection('right'), 100);
-                  }
-                }
+                const nextScenario = getNextSharedIntelligenceScenario();
+                setCurrentSharedIntelligenceScenario(nextScenario);
               }, 2000);
             }}
           />


### PR DESCRIPTION
## Summary
• Fix mobile demo animations to loop continuously between scenarios like desktop
• Prevent mobile chat containers from randomly disappearing 
• Make mobile demos independent and always active

## Changes Made
• **Looping Fix**: Removed section toggling logic from mobile onComplete callbacks - each demo now loops independently
• **Container Visibility**: Separated GSAP initialization for desktop vs mobile containers so mobile containers always have `opacity: 1`
• **Independence**: Made both mobile chat demos always active (`isActive={true}`) instead of depending on `activeSection`
• **Clean Restarts**: Added unique keys to mobile ChatDemoFull components for proper component remounting

## Test Plan
- [x] Verify both mobile chat animations start and loop continuously
- [x] Confirm mobile containers never disappear during animation cycles
- [x] Check that scenarios cycle properly through available options
- [x] Ensure desktop functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)