### PR TITLE
feat: add email notifications for founder contact messages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "posthog-js": "^1.260.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "resend": "^6.0.1",
         "split-type": "^0.3.4",
         "tailwind-merge": "^3.3.1",
         "task-master-ai": "^0.22.0",
@@ -1444,6 +1445,8 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "require-in-the-middle": ["require-in-the-middle@7.5.2", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3", "resolve": "^1.22.8" } }, "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ=="],
+
+    "resend": ["resend@6.0.1", "", { "peerDependencies": { "@react-email/render": "^1.1.0" }, "optionalPeers": ["@react-email/render"] }, "sha512-xNZ0gKAOqQcH83lXsqNOwBbpKROnsZpQr9mXRdG6hrHTF9G9Il2pkoTRtq7rJzXMvCZX+I79oahsbSeaYOWRFA=="],
 
     "resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type {
   FilterApi,
   FunctionReference,
 } from "convex/server";
+import type * as emailNotifications from "../emailNotifications.js";
 import type * as founderMessages from "../founderMessages.js";
 import type * as waitlist from "../waitlist.js";
 
@@ -25,6 +26,7 @@ import type * as waitlist from "../waitlist.js";
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  emailNotifications: typeof emailNotifications;
   founderMessages: typeof founderMessages;
   waitlist: typeof waitlist;
 }>;

--- a/convex/emailNotifications.ts
+++ b/convex/emailNotifications.ts
@@ -1,0 +1,86 @@
+import { action } from "./_generated/server";
+import { v } from "convex/values";
+import { Resend } from "resend";
+
+// Email notification action for new founder messages
+export const sendFounderMessageNotification = action({
+  args: {
+    name: v.string(),
+    email: v.string(),
+    company: v.optional(v.string()),
+    message: v.string(),
+    timestamp: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const resendApiKey = process.env.RESEND_API_KEY;
+    const founderEmails = process.env.FOUNDER_EMAIL || "founder@akarii.com";
+    
+    // Parse multiple emails separated by commas
+    const notificationEmails = founderEmails
+      .split(',')
+      .map(email => email.trim())
+      .filter(email => email.length > 0);
+
+    if (!resendApiKey) {
+      console.warn("RESEND_API_KEY not configured - email notification skipped");
+      return { success: false, error: "Email not configured" };
+    }
+
+    try {
+      const resend = new Resend(resendApiKey);
+
+      const formattedDate = new Date(args.timestamp).toLocaleString('en-US', {
+        timeZone: 'America/New_York',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+
+      const emailHtml = `
+        <div style="font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; max-width: 600px; margin: 0 auto; background-color: #000; color: #fff; padding: 20px; border-radius: 8px;">
+          <div style="text-align: center; margin-bottom: 30px;">
+            <h1 style="color: #fff; margin: 0; font-size: 24px;">New Founder Message</h1>
+            <p style="color: #999; margin: 5px 0;">Someone reached out through the Akarii contact form</p>
+          </div>
+          
+          <div style="background-color: #111; padding: 20px; border-radius: 8px; margin-bottom: 20px;">
+            <h2 style="color: #fff; margin-top: 0; font-size: 18px;">Contact Details</h2>
+            <p style="margin: 8px 0;"><strong style="color: #ccc;">Name:</strong> ${args.name}</p>
+            <p style="margin: 8px 0;"><strong style="color: #ccc;">Email:</strong> <a href="mailto:${args.email}" style="color: #4A9EFF;">${args.email}</a></p>
+            ${args.company ? `<p style="margin: 8px 0;"><strong style="color: #ccc;">Company:</strong> ${args.company}</p>` : ''}
+            <p style="margin: 8px 0;"><strong style="color: #ccc;">Submitted:</strong> ${formattedDate}</p>
+          </div>
+          
+          <div style="background-color: #111; padding: 20px; border-radius: 8px;">
+            <h2 style="color: #fff; margin-top: 0; font-size: 18px;">Message</h2>
+            <div style="background-color: #222; padding: 15px; border-radius: 6px; border-left: 4px solid #4A9EFF;">
+              <p style="margin: 0; line-height: 1.5; white-space: pre-wrap;">${args.message}</p>
+            </div>
+          </div>
+          
+          <div style="text-align: center; margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+            <p style="color: #666; font-size: 14px; margin: 0;">
+              Reply directly to this email to respond to ${args.name}
+            </p>
+          </div>
+        </div>
+      `;
+
+      const result = await resend.emails.send({
+        from: "Akarii Contact Form <noreply@akarii.ai>",
+        to: notificationEmails,
+        replyTo: args.email,
+        subject: `New message from ${args.name}${args.company ? ` (${args.company})` : ''}`,
+        html: emailHtml,
+      });
+
+      console.log("Email notification sent successfully:", result.id);
+      return { success: true, emailId: result.id };
+    } catch (error) {
+      console.error("Failed to send email notification:", error);
+      return { success: false, error: error.message };
+    }
+  },
+});

--- a/convex/emailNotifications.ts
+++ b/convex/emailNotifications.ts
@@ -1,9 +1,9 @@
-import { action } from "./_generated/server";
+import { internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { Resend } from "resend";
 
 // Email notification action for new founder messages
-export const sendFounderMessageNotification = action({
+export const sendFounderMessageNotification = internalAction({
   args: {
     name: v.string(),
     email: v.string(),
@@ -76,11 +76,11 @@ export const sendFounderMessageNotification = action({
         html: emailHtml,
       });
 
-      console.log("Email notification sent successfully:", result.id);
-      return { success: true, emailId: result.id };
+      console.log("Email notification sent successfully:", result.data?.id);
+      return { success: true, emailId: result.data?.id };
     } catch (error) {
       console.error("Failed to send email notification:", error);
-      return { success: false, error: error.message };
+      return { success: false, error: error instanceof Error ? error.message : "Unknown error" };
     }
   },
 });

--- a/convex/founderMessages.ts
+++ b/convex/founderMessages.ts
@@ -1,5 +1,6 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
+import { internal } from "./_generated/api";
 
 // Add a message to the founder
 export const addFounderMessage = mutation({
@@ -43,7 +44,7 @@ export const addFounderMessage = mutation({
 
     // Send email notification
     try {
-      await ctx.scheduler.runAfter(0, "emailNotifications:sendFounderMessageNotification", {
+      await ctx.scheduler.runAfter(0, internal.emailNotifications.sendFounderMessageNotification, {
         name: args.name.trim(),
         email: args.email.toLowerCase().trim(),
         company: args.company?.trim(),

--- a/convex/founderMessages.ts
+++ b/convex/founderMessages.ts
@@ -27,17 +27,33 @@ export const addFounderMessage = mutation({
       throw new Error("Message is required");
     }
 
+    const timestamp = Date.now();
+
     // Add the message to the founder messages
     const messageId = await ctx.db.insert("founderMessages", {
       name: args.name.trim(),
       email: args.email.toLowerCase().trim(),
       company: args.company?.trim() || undefined,
       message: args.message.trim(),
-      timestamp: Date.now(),
+      timestamp,
       userAgent: args.userAgent,
       referrer: args.referrer,
       status: "new",
     });
+
+    // Send email notification
+    try {
+      await ctx.scheduler.runAfter(0, "emailNotifications:sendFounderMessageNotification", {
+        name: args.name.trim(),
+        email: args.email.toLowerCase().trim(),
+        company: args.company?.trim(),
+        message: args.message.trim(),
+        timestamp,
+      });
+    } catch (error) {
+      console.error("Failed to schedule email notification:", error);
+      // Don't fail the message insertion if email fails
+    }
 
     return messageId;
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "posthog-js": "^1.260.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "resend": "^6.0.1",
     "split-type": "^0.3.4",
     "tailwind-merge": "^3.3.1",
     "task-master-ai": "^0.22.0"


### PR DESCRIPTION
## Summary
• Adds automatic email notifications when someone submits the founder contact form
• Supports multiple recipient emails for team notifications
• Professional email template with Akarii branding and reply-to functionality

## Changes Made
• **Email Service**: Integrated Resend for reliable email delivery
• **Multiple Recipients**: Support comma-separated emails in FOUNDER_EMAIL env var
• **Professional Template**: Dark-themed HTML email matching Akarii brand
• **Auto-Trigger**: Notifications sent immediately after form submission
• **Reply-To**: Recipients can reply directly to respond to the sender
• **Graceful Fallback**: Form submission works even if email fails

## Configuration Required
```bash
# Add to .env.local
RESEND_API_KEY=your_resend_api_key
FOUNDER_EMAIL=hello@akarii.ai,kuoloon@hotmail.com
```

## Features
• ✅ Multiple email recipients
• ✅ Professional styled emails
• ✅ All form details included
• ✅ Timestamp formatting
• ✅ Reply-to functionality
• ✅ Error handling & fallbacks
• ✅ No impact on form UX if email fails

## Test Plan
- [x] Email template renders correctly
- [x] Multiple recipients receive notifications
- [x] Reply-to functionality works
- [x] Form still works if email service fails
- [x] Professional styling matches brand
- [x] All contact details included in email

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Founder notifications are now sent by email when new messages are submitted; emails include sender details, company, message, and submission time and support multiple recipient founders.
* **Bug Fixes**
  * Message creation now succeeds even if email delivery fails; failures are logged without blocking submission.
* **Chores**
  * Added the email delivery service dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->