### PR TITLE
fix: connect 'Talk to Founder' buttons to contact page

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -254,6 +254,7 @@ export default function Hero() {
               ref={buttonRef2}
               icon={<ExternalLink size={16} />}
               className="w-full md:w-auto opacity-0 invisible translate-y-[30px]"
+              onClick={() => window.location.href = '/contact'}
             >
               Talk to Founder
             </Button>

--- a/src/components/sections/Navigation.tsx
+++ b/src/components/sections/Navigation.tsx
@@ -26,7 +26,10 @@ export default function Navigation() {
             >
               Join Waitlist
             </button>
-            <button className="text-text-secondary hover:text-text-primary transition-colors text-body-sm">
+            <button 
+              onClick={() => window.location.href = '/contact'}
+              className="text-text-secondary hover:text-text-primary transition-colors text-body-sm"
+            >
               Talk to Founder
             </button>
           </div>


### PR DESCRIPTION
## Summary
- Fixed missing navigation functionality for 'Talk to Founder' buttons
- Added onClick handlers in both Hero and Navigation components to navigate to /contact

## Changes Made
- `src/components/sections/Hero.tsx`: Added onClick handler to Talk to Founder button
- `src/components/sections/Navigation.tsx`: Added onClick handler to Talk to Founder button  

## Test Plan
- [x] Verified contact page exists at `/contact` route
- [x] Added navigation handlers to both button instances
- [ ] Manual testing: Click "Talk to Founder" buttons to verify navigation works

🤖 Generated with [Claude Code](https://claude.ai/code)